### PR TITLE
fix: add missing refitting options and missing translations

### DIFF
--- a/lang/english.lng
+++ b/lang/english.lng
@@ -18,9 +18,9 @@ STR_BUS_COACH   :{BLACK}Usage: {ORANGE}coach
 STR_BUS_REGIONAL:{BLACK}Usage: {ORANGE}regional lines
 
 STR_TRUCK_AUTOREFIT      :{BLACK}Refittable in stations.
-STR_CFG_TRUCK            :{BLACK}Configuration: {ORANGE}lorry
-STR_CFG_TRUCK_TRAILER    :{BLACK}Configuration: {ORANGE}lorry with trailer
-STR_CFG_TRUCK_SEMITRAILER:{BLACK}Configuration: {ORANGE}articulated lorry
+STR_CFG_TRUCK            :{BLACK}Configuration: {YELLOW}lorry
+STR_CFG_TRUCK_TRAILER    :{BLACK}Configuration: {YELLOW}lorry with trailer
+STR_CFG_TRUCK_SEMITRAILER:{BLACK}Configuration: {YELLOW}articulated lorry
 
 # Buses
 BUS_VOMAG_P20            :Vomag P20f

--- a/lang/english_us.lng
+++ b/lang/english_us.lng
@@ -3,6 +3,6 @@
 # This is the English (US) language file
 # Most strings are the same as for the default english.lng
 
-STR_CFG_TRUCK            :{BLACK}Configuration: {ORANGE}truck
-STR_CFG_TRUCK_TRAILER    :{BLACK}Configuration: {ORANGE}truck with trailer
-STR_CFG_TRUCK_SEMITRAILER:{BLACK}Configuration: {ORANGE}semi-trailer truck
+STR_CFG_TRUCK            :{BLACK}Configuration: {YELLOW}truck
+STR_CFG_TRUCK_TRAILER    :{BLACK}Configuration: {YELLOW}truck with trailer
+STR_CFG_TRUCK_SEMITRAILER:{BLACK}Configuration: {YELLOW}semi-trailer truck

--- a/lang/german.lng
+++ b/lang/german.lng
@@ -14,7 +14,11 @@ STR_PARAM_CARGO_CAPACITY_DESC: Skaliert die Menge an Fracht, die ein Fahrzeug tr
 STR_BUS_CITY    :{BLACK}Verwendung: {ORANGE}Stadtbus
 STR_BUS_COACH   :{BLACK}Verwendung: {ORANGE}Reisebus
 STR_BUS_REGIONAL:{BLACK}Verwendung: {ORANGE}Regionalbus
+
 STR_TRUCK_AUTOREFIT:{BLACK}Umrüstbar an Haltestellen.
+STR_CFG_TRUCK            :{BLACK}Konfiguration: {YELLOW}Lastwagen
+STR_CFG_TRUCK_TRAILER    :{BLACK}Konfiguration: {YELLOW}Lastwagen mit Anhänger
+STR_CFG_TRUCK_SEMITRAILER:{BLACK}Konfiguration: {YELLOW}Sattelzug
 
 # Trucks
 TRUCK_BUSSING_IIIGL_OPEN      :Büssing III GL (Kipper)

--- a/src/truck/33_buessingIIIGL.pnml
+++ b/src/truck/33_buessingIIIGL.pnml
@@ -212,7 +212,7 @@ item(FEAT_ROADVEHS, ID_33_BUSSING_IIIGL_closed) {
         air_drag_coefficient: 0;
         retire_early:7;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED);
 		variant_group: ID_33_BUSSING_IIIGL_tarpaulin;
 	}

--- a/src/truck/34_buessingVIGL.pnml
+++ b/src/truck/34_buessingVIGL.pnml
@@ -212,7 +212,7 @@ item(FEAT_ROADVEHS, ID_34_BUSSING_VIGL_closed) {
         air_drag_coefficient: 0;
         retire_early:7;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED);
 		variant_group: ID_34_BUSSING_VIGL_tarpaulin;
 	}

--- a/src/truck/36_henschel36w3.pnml
+++ b/src/truck/36_henschel36w3.pnml
@@ -339,7 +339,7 @@ item(FEAT_ROADVEHS, ID_36_henschel36w3_closed) {
         air_drag_coefficient: 0;
         retire_early:0;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED);
 		variant_group: ID_36_henschel36w3_tarpaulin;
 	}
@@ -375,7 +375,7 @@ item(FEAT_ROADVEHS, ID_36_henschel36w3_closed_with_trailer) {
         air_drag_coefficient: 0;
         retire_early:0;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED);
 		variant_group: ID_36_henschel36w3_tarpaulin;
 	}

--- a/src/truck/37_bussing5000.pnml
+++ b/src/truck/37_bussing5000.pnml
@@ -339,7 +339,7 @@ item(FEAT_ROADVEHS, ID_37_bussing5000_closed) {
         air_drag_coefficient: 0;
         retire_early:2;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED);
 		variant_group: ID_37_bussing5000_tarpaulin;
 	}
@@ -375,7 +375,7 @@ item(FEAT_ROADVEHS, ID_37_bussing5000_closed_with_trailer) {
         air_drag_coefficient: 0;
         retire_early:2;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED);
 		variant_group: ID_37_bussing5000_tarpaulin;
 	}

--- a/src/truck/38_bussing8000.pnml
+++ b/src/truck/38_bussing8000.pnml
@@ -338,7 +338,7 @@ item(FEAT_ROADVEHS, ID_38_bussing8000_closed) {
         air_drag_coefficient: 0;
         retire_early:12;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED);
 		variant_group: ID_38_bussing8000_tarpaulin;
 	}
@@ -374,7 +374,7 @@ item(FEAT_ROADVEHS, ID_38_bussing8000_closed_with_trailer) {
         air_drag_coefficient: 0;
         retire_early:12;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED);
 		variant_group: ID_38_bussing8000_tarpaulin;
 	}

--- a/src/truck/39_henschel_hs140.pnml
+++ b/src/truck/39_henschel_hs140.pnml
@@ -173,7 +173,7 @@ item(FEAT_ROADVEHS, ID_39_henschel_hs140_closed) {
         air_drag_coefficient: 0;
         retire_early:0;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED);
 		variant_group: ID_39_henschel_hs140_tarpaulin;
 	}

--- a/src/truck/49_mbactros2540.pnml
+++ b/src/truck/49_mbactros2540.pnml
@@ -1008,7 +1008,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_container) {
         air_drag_coefficient: 0;
         retire_early:7;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT, ROADVEH_FLAG_SPRITE_STACK);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED, CC_BULK);
 		variant_group: ID_49_mbactros2540_tarpaulin;
 	}
@@ -1045,7 +1045,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_container_with_trailer) {
         air_drag_coefficient: 0;
         retire_early:7;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT, ROADVEH_FLAG_SPRITE_STACK);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED, CC_BULK);
 		variant_group: ID_49_mbactros2540_tarpaulin;
 	}

--- a/src/truck/4B_mbaxor.pnml
+++ b/src/truck/4B_mbaxor.pnml
@@ -476,7 +476,7 @@ item(FEAT_ROADVEHS, ID_4B_mb_axor_container) {
         air_drag_coefficient: 0;
         retire_early:0;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT, ROADVEH_FLAG_SPRITE_STACK);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED, CC_BULK);
 		variant_group: ID_4B_mb_axor_tarpaulin;
 	}

--- a/src/truck/4E_mbactros2_2541.pnml
+++ b/src/truck/4E_mbactros2_2541.pnml
@@ -1008,7 +1008,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_container) {
         air_drag_coefficient: 0;
         retire_early:7;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT, ROADVEH_FLAG_SPRITE_STACK);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED, CC_BULK);
 		variant_group: ID_4E_mbactros2_2541_tarpaulin;
 	}
@@ -1045,7 +1045,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_container_with_trailer) {
         air_drag_coefficient: 0;
         retire_early:7;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT, ROADVEH_FLAG_SPRITE_STACK);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED, CC_BULK);
 		variant_group: ID_4E_mbactros2_2541_tarpaulin;
 	}

--- a/src/truck/51_mantgx.pnml
+++ b/src/truck/51_mantgx.pnml
@@ -477,7 +477,7 @@ item(FEAT_ROADVEHS, ID_51_mantgx_container) {
         air_drag_coefficient: 0;
         retire_early:0;
         misc_flags: bitmask(ROADVEH_FLAG_2CC, ROADVEH_FLAG_AUTOREFIT, ROADVEH_FLAG_SPRITE_STACK);
-		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED);
+		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_ARMOURED, CC_COVERED, CC_REFRIGERATED, CC_HAZARDOUS);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED, CC_BULK);
 		variant_group: ID_51_mantgx_tarpaulin;
 	}


### PR DESCRIPTION
Hazardous goods were missing in the refit options, so transporting certain cargos was not possible.
Some translations were also missing.