### PR TITLE
fix: wrong capacities displayed in purchase menu, MAN TGA XXL not working

### DIFF
--- a/src/truck/36_henschel36w3.pnml
+++ b/src/truck/36_henschel36w3.pnml
@@ -134,7 +134,7 @@ switch(FEAT_ROADVEHS, SELF, henschel36w3_cb_cargo_capacity,
 }
 
 switch(FEAT_ROADVEHS, SELF, henschel36w3_open_cb_articulation, extra_callback_info1) {
-	1: return ID_36_henschel36w3_open;
+	1: return ID_36_henschel36w3_open_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -213,13 +213,14 @@ item(FEAT_ROADVEHS, ID_36_henschel36w3_open_with_trailer) {
 		default: henschel36w3_switch_graphics_open;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: henschel36w3_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:henschel36w3_open_cb_articulation;
 		purchase: henschel36w3_open_menu;
 	}
 }
 
 switch(FEAT_ROADVEHS, SELF, henschel36w3_tarpaulin_cb_articulation, extra_callback_info1) {
-	1: return ID_36_henschel36w3_tarpaulin;
+	1: return ID_36_henschel36w3_tarpaulin_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -298,13 +299,16 @@ item(FEAT_ROADVEHS, ID_36_henschel36w3_tarpaulin_with_trailer) {
 		default: henschel36w3_switch_graphics_tarpaulin;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: henschel36w3_cb_cargo_capacity;
+		// full capacity is 24t, but goods are 0.5t per item
+		// however, a crate of goods (default cargo) has .5t, so the value needs to be *2 here
+		purchase_cargo_capacity: return 24*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:henschel36w3_tarpaulin_cb_articulation;
 		purchase: henschel36w3_tarpaulin_menu;
 	}
 }
 
 switch(FEAT_ROADVEHS, SELF, henschel36w3_closed_cb_articulation, extra_callback_info1) {
-	1: return ID_36_henschel36w3_closed;
+	1: return ID_36_henschel36w3_closed_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -383,13 +387,15 @@ item(FEAT_ROADVEHS, ID_36_henschel36w3_closed_with_trailer) {
 		default: henschel36w3_switch_graphics_closed;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: henschel36w3_cb_cargo_capacity;
+		// full capacity is 24t, but goods are 0.5t per item
+		purchase_cargo_capacity: return 24*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:henschel36w3_closed_cb_articulation;
 		purchase: henschel36w3_closed_menu;
 	}
 }
 
 switch(FEAT_ROADVEHS, SELF, henschel36w3_tanker_cb_articulation, extra_callback_info1) {
-	1: return ID_36_henschel36w3_tanker;
+	1: return ID_36_henschel36w3_tanker_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -463,6 +469,7 @@ item(FEAT_ROADVEHS, ID_36_henschel36w3_tanker_with_trailer) {
 	graphics {
 		default: henschel36w3_switch_graphics_tanker;
 		cargo_capacity: henschel36w3_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_CFG_TRUCK_TRAILER);
 		articulated_part:henschel36w3_tanker_cb_articulation;
 		purchase: henschel36w3_tanker_menu;

--- a/src/truck/37_bussing5000.pnml
+++ b/src/truck/37_bussing5000.pnml
@@ -135,7 +135,7 @@ switch(FEAT_ROADVEHS, SELF, bussing5000_cb_cargo_capacity,
 }
 
 switch(FEAT_ROADVEHS, SELF, bussing5000_open_cb_articulation, extra_callback_info1) {
-	1: return ID_37_bussing5000_open;
+	1: return ID_37_bussing5000_open_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -214,13 +214,14 @@ item(FEAT_ROADVEHS, ID_37_bussing5000_open_with_trailer) {
 		default: bussing5000_switch_graphics_open;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: bussing5000_cb_cargo_capacity;
+		purchase_cargo_capacity: return 8*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:bussing5000_open_cb_articulation;
 		purchase: bussing5000_open_menu;
 	}
 }
 
 switch(FEAT_ROADVEHS, SELF, bussing5000_tarpaulin_cb_articulation, extra_callback_info1) {
-	1: return ID_37_bussing5000_tarpaulin;
+	1: return ID_37_bussing5000_tarpaulin_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -298,13 +299,15 @@ item(FEAT_ROADVEHS, ID_37_bussing5000_tarpaulin_with_trailer) {
 		default: bussing5000_switch_graphics_tarpaulin;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: bussing5000_cb_cargo_capacity;
+		// full capacity is 16t, but goods are 0.5t per item
+		purchase_cargo_capacity: return 8*2*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:bussing5000_tarpaulin_cb_articulation;
 		purchase: bussing5000_tarpaulin_menu;
 	}
 }
 
 switch(FEAT_ROADVEHS, SELF, bussing5000_closed_cb_articulation, extra_callback_info1) {
-	1: return ID_37_bussing5000_closed;
+	1: return ID_37_bussing5000_closed_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -383,13 +386,15 @@ item(FEAT_ROADVEHS, ID_37_bussing5000_closed_with_trailer) {
 		default: bussing5000_switch_graphics_closed;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: bussing5000_cb_cargo_capacity;
+		// full capacity is 16t, but goods are 0.5t per item
+		purchase_cargo_capacity: return 8*2*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:bussing5000_closed_cb_articulation;
 		purchase: bussing5000_closed_menu;
 	}
 }
 
 switch(FEAT_ROADVEHS, SELF, bussing5000_tanker_cb_articulation, extra_callback_info1) {
-	1: return ID_37_bussing5000_tanker;
+	1: return ID_37_bussing5000_tanker_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -463,6 +468,7 @@ item(FEAT_ROADVEHS, ID_37_bussing5000_tanker_with_trailer) {
 	graphics {
 		default: bussing5000_switch_graphics_tanker;
 		cargo_capacity: bussing5000_cb_cargo_capacity;
+		purchase_cargo_capacity: return 8 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_CFG_TRUCK_TRAILER);
 		articulated_part:bussing5000_tanker_cb_articulation;
 		purchase: bussing5000_tanker_menu;

--- a/src/truck/38_bussing8000.pnml
+++ b/src/truck/38_bussing8000.pnml
@@ -134,7 +134,7 @@ switch(FEAT_ROADVEHS, SELF, bussing8000_cb_cargo_capacity,
 }
 
 switch(FEAT_ROADVEHS, SELF, bussing8000_open_cb_articulation, extra_callback_info1) {
-	1: return ID_38_bussing8000_open;
+	1: return ID_38_bussing8000_open_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -213,13 +213,14 @@ item(FEAT_ROADVEHS, ID_38_bussing8000_open_with_trailer) {
 		default: bussing8000_switch_graphics_open;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: bussing8000_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:bussing8000_open_cb_articulation;
 		purchase: bussing8000_open_menu;
 	}
 }
 
 switch(FEAT_ROADVEHS, SELF, bussing8000_tarpaulin_cb_articulation, extra_callback_info1) {
-	1: return ID_38_bussing8000_tarpaulin;
+	1: return ID_38_bussing8000_tarpaulin_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -297,13 +298,15 @@ item(FEAT_ROADVEHS, ID_38_bussing8000_tarpaulin_with_trailer) {
 		default: bussing8000_switch_graphics_tarpaulin;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: bussing8000_cb_cargo_capacity;
+		// full capacity is 24t, but goods are 0.5t per item
+		purchase_cargo_capacity: return 24*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:bussing8000_tarpaulin_cb_articulation;
 		purchase: bussing8000_tarpaulin_menu;
 	}
 }
 
 switch(FEAT_ROADVEHS, SELF, bussing8000_closed_cb_articulation, extra_callback_info1) {
-	1: return ID_38_bussing8000_closed;
+	1: return ID_38_bussing8000_closed_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -382,13 +385,15 @@ item(FEAT_ROADVEHS, ID_38_bussing8000_closed_with_trailer) {
 		default: bussing8000_switch_graphics_closed;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: bussing8000_cb_cargo_capacity;
+		// full capacity is 24t, but goods are 0.5t per item
+		purchase_cargo_capacity: return 24*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:bussing8000_closed_cb_articulation;
 		purchase: bussing8000_closed_menu;
 	}
 }
 
 switch(FEAT_ROADVEHS, SELF, bussing8000_tanker_cb_articulation, extra_callback_info1) {
-	1: return ID_38_bussing8000_tanker;
+	1: return ID_38_bussing8000_tanker_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -462,6 +467,7 @@ item(FEAT_ROADVEHS, ID_38_bussing8000_tanker_with_trailer) {
 	graphics {
 		default: bussing8000_switch_graphics_tanker;
 		cargo_capacity: bussing8000_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_CFG_TRUCK_TRAILER);
 		articulated_part:bussing8000_tanker_cb_articulation;
 		purchase: bussing8000_tanker_menu;

--- a/src/truck/39_henschel_hs140.pnml
+++ b/src/truck/39_henschel_hs140.pnml
@@ -113,7 +113,7 @@ item(FEAT_ROADVEHS, ID_39_henschel_hs140_tarpaulin) {
         running_cost_base:RUNNING_COST_ROADVEH;
         sprite_id:SPRITE_ID_NEW_ROADVEH;
         cargo_capacity:12; // 8t + 16t in trailer
-		default_cargo_type:DEFAULT_CARGO_FIRST_REFITTABLE;
+		default_cargo_type:GOOD;
 		cost_factor:4;
 		refit_cost:0;
 		sound_effect:SOUND_DEPARTURE_OLD_RV_1;
@@ -131,7 +131,9 @@ item(FEAT_ROADVEHS, ID_39_henschel_hs140_tarpaulin) {
 		default: henschel_hs140_switch_graphics_tarpaulin;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_SEMITRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: henschel_hs140_cb_cargo_capacity;
-		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
+		// actually it should be 12t (because it is automatically *2 due to articulation),
+		// however, a crate of goods (default cargo) has .5t, so the value needs to be *2 here
+		purchase_cargo_capacity: return 24*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:henschel_hs140_tarpaulin_cb_articulation;
 		purchase: henschel_hs140_tarpaulin_menu;
 	}
@@ -162,7 +164,7 @@ item(FEAT_ROADVEHS, ID_39_henschel_hs140_closed) {
         running_cost_base:RUNNING_COST_ROADVEH;
         sprite_id:SPRITE_ID_NEW_ROADVEH;
         cargo_capacity:12; // 8t + 16t in trailer
-		default_cargo_type:DEFAULT_CARGO_FIRST_REFITTABLE;
+		default_cargo_type:GOOD;
 		cost_factor:4;
 		refit_cost:0;
 		sound_effect:SOUND_DEPARTURE_OLD_RV_1;
@@ -181,7 +183,9 @@ item(FEAT_ROADVEHS, ID_39_henschel_hs140_closed) {
 		default: henschel_hs140_switch_graphics_closed;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_SEMITRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: henschel_hs140_cb_cargo_capacity;
-		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
+		// actually it should be 12t (because it is automatically *2 due to articulation),
+		// however, a crate of goods (default cargo) has .5t, so the value needs to be *2 here
+		purchase_cargo_capacity: return 24*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:henschel_hs140_closed_cb_articulation;
 		purchase: henschel_hs140_closed_menu;
 	}

--- a/src/truck/49_mbactros2540.pnml
+++ b/src/truck/49_mbactros2540.pnml
@@ -262,7 +262,7 @@ switch(FEAT_ROADVEHS, SELF, mbactros2540_switch_graphics_open, position_in_consi
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2540_open_cb_articulation, extra_callback_info1) {
-	1: return ID_49_mbactros2540_open;
+	1: return ID_49_mbactros2540_open_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -336,13 +336,14 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_open_with_trailer) {
 		default: mbactros2540_switch_graphics_open;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: mbactros2540_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:mbactros2540_open_cb_articulation;
 		purchase: mbactros2540_open_menu;
 	}
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2540_tarpaulin_cb_articulation, extra_callback_info1) {
-	1: return ID_49_mbactros2540_tarpaulin;
+	1: return ID_49_mbactros2540_tarpaulin_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -417,18 +418,21 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_tarpaulin_with_trailer) {
 		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_PIECE_GOODS, CC_COVERED);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED, CC_HAZARDOUS, CC_REFRIGERATED);
 		cargo_disallow_refit: [WOOD, STEL, LVST];
+		variant_group: ID_49_mbactros2540_tarpaulin;
 	}
 	graphics {
 		default: mbactros2540_switch_graphics_tarpaulin;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: mbactros2540_cb_cargo_capacity;
+		// full capacity is 24t, but goods are 0.5t per item
+		purchase_cargo_capacity: return 24*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:mbactros2540_tarpaulin_cb_articulation;
 		purchase: mbactros2540_tarpaulin_menu;
 	}
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2540_silo_cb_articulation, extra_callback_info1) {
-	1: return ID_49_mbactros2540_silo;
+	1: return ID_49_mbactros2540_silo_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -502,6 +506,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_silo_with_trailer) {
 	graphics {
 		default: mbactros2540_switch_graphics_silo;
 		cargo_capacity: mbactros2540_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_CFG_TRUCK_TRAILER);
 		articulated_part:mbactros2540_silo_cb_articulation;
 		purchase: mbactros2540_silo_menu;
@@ -509,7 +514,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_silo_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2540_tanker_cb_articulation, extra_callback_info1) {
-	1: return ID_49_mbactros2540_tanker;
+	1: return ID_49_mbactros2540_tanker_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -583,6 +588,8 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_tanker_with_trailer) {
 	graphics {
 		default: mbactros2540_switch_graphics_tanker;
 		cargo_capacity: mbactros2540_cb_cargo_capacity;
+		// full capacity is 24t, but goods are 0.5t per item
+		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_CFG_TRUCK_TRAILER);
 		articulated_part:mbactros2540_tanker_cb_articulation;
 		purchase:mbactros2540_tanker_menu;
@@ -590,7 +597,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_tanker_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2540_livestock_cb_articulation, extra_callback_info1) {
-	1: return ID_49_mbactros2540_livestock;
+	1: return ID_49_mbactros2540_livestock_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -613,7 +620,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_livestock) {
         running_cost_factor:7;
         running_cost_base:RUNNING_COST_ROADVEH;
         sprite_id:SPRITE_ID_NEW_ROADVEH;
-        cargo_capacity:12; // 8t + 16t in trailer
+        cargo_capacity:8;
 		default_cargo_type:LVST;
 		cost_factor:4;
 		sound_effect:SOUND_DEPARTURE_OLD_RV_2;
@@ -663,6 +670,8 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_livestock_with_trailer) {
 	graphics {
 		default: mbactros2540_switch_graphics_livestock;
 		cargo_capacity: mbactros2540_cb_cargo_capacity;
+		// full capacity is 24t, but lvst are 0.25t per item
+		purchase_cargo_capacity: return (32*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100)-1; // doubled due to articulation, don't know where that -1 comes from...
 		additional_text: return string(STR_CFG_TRUCK_TRAILER);
 		articulated_part:mbactros2540_livestock_cb_articulation;
 		purchase: mbactros2540_livestock_menu;
@@ -670,7 +679,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_livestock_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2540_wood_cb_articulation, extra_callback_info1) {
-	1: return ID_49_mbactros2540_wood;
+	1: return ID_49_mbactros2540_wood_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -746,6 +755,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_wood_with_trailer) {
 	graphics {
 		default: mbactros2540_switch_graphics_wood;
 		cargo_capacity: mbactros2540_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		articulated_part:mbactros2540_wood_cb_articulation;
 		purchase:mbactros2540_wood_menu;
@@ -753,7 +763,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_wood_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2540_vehicles_cb_articulation, extra_callback_info1) {
-	1: return ID_49_mbactros2540_vehicles;
+	1: return ID_49_mbactros2540_vehicles_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -895,6 +905,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_vehicles_with_trailer) {
 	graphics {
 		default: mbactros2540_switch_graphics_vehicles;
 		cargo_capacity: mbactros2540_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_CFG_TRUCK_TRAILER);
 		articulated_part:mbactros2540_vehicles_cb_articulation;
 		random_trigger: mbactros2540_graphics_vehicles_random_freight_color;
@@ -903,7 +914,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_vehicles_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2540_container_cb_articulation, extra_callback_info1) {
-	1: return ID_49_mbactros2540_container;
+	1: return ID_49_mbactros2540_container_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -997,7 +1008,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_container) {
         running_cost_base:RUNNING_COST_ROADVEH;
         sprite_id:SPRITE_ID_NEW_ROADVEH;
         cargo_capacity:8;
-		default_cargo_type:DEFAULT_CARGO_FIRST_REFITTABLE;
+		default_cargo_type:GOOD;
 		cost_factor:4;
 		refit_cost:0;
 		sound_effect:SOUND_DEPARTURE_OLD_RV_2;
@@ -1034,7 +1045,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_container_with_trailer) {
         running_cost_base:RUNNING_COST_ROADVEH;
         sprite_id:SPRITE_ID_NEW_ROADVEH;
         cargo_capacity:12; // 8t + 16t in trailer
-		default_cargo_type:DEFAULT_CARGO_FIRST_REFITTABLE;
+		default_cargo_type:GOOD;
 		cost_factor:4;
 		refit_cost:0;
 		sound_effect:SOUND_DEPARTURE_OLD_RV_2;
@@ -1052,6 +1063,8 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_container_with_trailer) {
 	graphics {
 		default: mbactros2540_switch_graphics_container;
 		cargo_capacity: mbactros2540_cb_cargo_capacity;
+		// full capacity is 24t, but goods are 0.5t per item
+		purchase_cargo_capacity: return 24*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		articulated_part:mbactros2540_container_cb_articulation;
 		random_trigger: mbactros2540_graphics_container_random_freight_color;
@@ -1060,7 +1073,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_container_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2540_refrigerated_cb_articulation, extra_callback_info1) {
-	1: return ID_49_mbactros2540_refrigerated;
+	1: return ID_49_mbactros2540_refrigerated_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -1136,6 +1149,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_refrigerated_with_trailer) {
 	graphics {
 		default: mbactros2540_switch_graphics_refrigerated;
 		cargo_capacity: mbactros2540_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_CFG_TRUCK_TRAILER);
 		articulated_part:mbactros2540_refrigerated_cb_articulation;
 		purchase:mbactros2540_refrigerated_menu;
@@ -1143,7 +1157,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_refrigerated_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2540_crane_cb_articulation, extra_callback_info1) {
-	1: return ID_49_mbactros2540_open_crane;
+	1: return ID_49_mbactros2540_open_crane_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -1174,7 +1188,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_open_crane) {
         running_cost_base:RUNNING_COST_ROADVEH;
         sprite_id:SPRITE_ID_NEW_ROADVEH;
         cargo_capacity:8;
-		default_cargo_type:GOOD;
+		default_cargo_type:STEL;
 		cost_factor:4;
 		refit_cost:0;
 		sound_effect:SOUND_DEPARTURE_OLD_RV_2;
@@ -1211,7 +1225,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_open_crane_with_trailer) {
         running_cost_base:RUNNING_COST_ROADVEH;
         sprite_id:SPRITE_ID_NEW_ROADVEH;
         cargo_capacity:12; // 8t + 16t in trailer
-		default_cargo_type:GOOD;
+		default_cargo_type:STEL;
 		cost_factor:4;
 		refit_cost:0;
 		sound_effect:SOUND_DEPARTURE_OLD_RV_2;
@@ -1231,6 +1245,7 @@ item(FEAT_ROADVEHS, ID_49_mbactros2540_open_crane_with_trailer) {
 		default: mbactros2540_switch_graphics_crane;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: mbactros2540_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:mbactros2540_crane_cb_articulation;
 		purchase:mbactros2540_open_crane_menu;
 	}

--- a/src/truck/4B_mbaxor.pnml
+++ b/src/truck/4B_mbaxor.pnml
@@ -133,7 +133,7 @@ item(FEAT_ROADVEHS, ID_4B_mb_axor_tarpaulin) {
         running_cost_base:RUNNING_COST_ROADVEH;
         sprite_id:SPRITE_ID_NEW_ROADVEH;
         cargo_capacity:13; // 26t in trailer
-		default_cargo_type:DEFAULT_CARGO_FIRST_REFITTABLE;
+		default_cargo_type:GOOD;
 		cost_factor:4;
 		refit_cost:0;
 		sound_effect:SOUND_DEPARTURE_OLD_RV_2;
@@ -151,7 +151,7 @@ item(FEAT_ROADVEHS, ID_4B_mb_axor_tarpaulin) {
 		default: mb_axor_switch_graphics_tarpaulin;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_SEMITRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: mb_axor_cb_cargo_capacity;
-		purchase_cargo_capacity: return 13 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
+		purchase_cargo_capacity: return 26 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:mb_axor_tarpaulin_cb_articulation;
 		purchase: mb_axor_tarpaulin_menu;
 	}
@@ -465,7 +465,7 @@ item(FEAT_ROADVEHS, ID_4B_mb_axor_container) {
         running_cost_base:RUNNING_COST_ROADVEH;
         sprite_id:SPRITE_ID_NEW_ROADVEH;
         cargo_capacity:13; // 26t in trailer
-		default_cargo_type:DEFAULT_CARGO_FIRST_REFITTABLE;
+		default_cargo_type:GOOD;
 		refit_cost:0;
 		cost_factor:4;
 		sound_effect:SOUND_DEPARTURE_OLD_RV_2;
@@ -484,7 +484,7 @@ item(FEAT_ROADVEHS, ID_4B_mb_axor_container) {
 		default: mb_axor_switch_graphics_container;
 		cargo_capacity: mb_axor_cb_cargo_capacity;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_SEMITRAILER), string(STR_TRUCK_AUTOREFIT));
-		purchase_cargo_capacity: return 13 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
+		purchase_cargo_capacity: return 26 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:mb_axor_container_cb_articulation;
 		purchase: mb_axor_container_menu;
 	}

--- a/src/truck/4E_mbactros2_2541.pnml
+++ b/src/truck/4E_mbactros2_2541.pnml
@@ -262,7 +262,7 @@ switch(FEAT_ROADVEHS, SELF, mbactros2_2541_switch_graphics_open, position_in_con
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2_2541_open_cb_articulation, extra_callback_info1) {
-	1: return ID_4E_mbactros2_2541_open;
+	1: return ID_4E_mbactros2_2541_open_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -336,13 +336,14 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_open_with_trailer) {
 		default: mbactros2_2541_switch_graphics_open;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: mbactros2_2541_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:mbactros2_2541_open_cb_articulation;
 		purchase: mbactros2_2541_open_menu;
 	}
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2_2541_tarpaulin_cb_articulation, extra_callback_info1) {
-	1: return ID_4E_mbactros2_2541_tarpaulin;
+	1: return ID_4E_mbactros2_2541_tarpaulin_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -417,10 +418,13 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_tarpaulin_with_trailer) {
 		refittable_cargo_classes:bitmask(CC_MAIL, CC_EXPRESS, CC_PIECE_GOODS, CC_COVERED);
 		non_refittable_cargo_classes:bitmask(CC_OVERSIZED, CC_HAZARDOUS, CC_REFRIGERATED);
 		cargo_disallow_refit: [WOOD, STEL, LVST];
+		variant_group: ID_4E_mbactros2_2541_tarpaulin;
 	}
 	graphics {
 		default: mbactros2_2541_switch_graphics_tarpaulin;
 		purchase: mbactros2_2541_tarpaulin_menu;
+		// full capacity is 24t, but goods are 0.5t per item
+		purchase_cargo_capacity: return 24*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: mbactros2_2541_cb_cargo_capacity;
 		articulated_part:mbactros2_2541_tarpaulin_cb_articulation;
@@ -428,7 +432,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_tarpaulin_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2_2541_silo_cb_articulation, extra_callback_info1) {
-	1: return ID_4E_mbactros2_2541_silo;
+	1: return ID_4E_mbactros2_2541_silo_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -502,6 +506,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_silo_with_trailer) {
 	graphics {
 		default: mbactros2_2541_switch_graphics_silo;
 		cargo_capacity: mbactros2_2541_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		articulated_part:mbactros2_2541_silo_cb_articulation;
 		purchase: mbactros2_2541_silo_menu;
@@ -509,7 +514,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_silo_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2_2541_tanker_cb_articulation, extra_callback_info1) {
-	1: return ID_4E_mbactros2_2541_tanker;
+	1: return ID_4E_mbactros2_2541_tanker_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -583,6 +588,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_tanker_with_trailer) {
 	graphics {
 		default: mbactros2_2541_switch_graphics_tanker;
 		cargo_capacity: mbactros2_2541_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_CFG_TRUCK_TRAILER);
 		articulated_part:mbactros2_2541_tanker_cb_articulation;
 		purchase: mbactros2_2541_tanker_menu;
@@ -590,7 +596,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_tanker_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2_2541_livestock_cb_articulation, extra_callback_info1) {
-	1: return ID_4E_mbactros2_2541_livestock;
+	1: return ID_4E_mbactros2_2541_livestock_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -664,13 +670,14 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_livestock_with_trailer) {
 		default: mbactros2_2541_switch_graphics_livestock;
 		purchase: mbactros2_2541_livestock_menu;
 		cargo_capacity: mbactros2_2541_cb_cargo_capacity;
+		purchase_cargo_capacity: return (32*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100)-1; // doubled due to articulation, don't know where that -1 comes from...
 		additional_text: return string(STR_CFG_TRUCK_TRAILER);
 		articulated_part:mbactros2_2541_livestock_cb_articulation;
 	}
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2_2541_wood_cb_articulation, extra_callback_info1) {
-	1: return ID_4E_mbactros2_2541_wood;
+	1: return ID_4E_mbactros2_2541_wood_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -746,6 +753,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_wood_with_trailer) {
 	graphics {
 		default: mbactros2_2541_switch_graphics_wood;
 		cargo_capacity: mbactros2_2541_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		articulated_part:mbactros2_2541_wood_cb_articulation;
 		purchase:mbactros2_2541_wood_menu;
@@ -753,7 +761,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_wood_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2_2541_vehicles_cb_articulation, extra_callback_info1) {
-	1: return ID_4E_mbactros2_2541_vehicles;
+	1: return ID_4E_mbactros2_2541_vehicles_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -895,6 +903,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_vehicles_with_trailer) {
 	graphics {
 		default: mbactros2_2541_switch_graphics_vehicles;
 		cargo_capacity: mbactros2_2541_cb_cargo_capacity;
+		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:mbactros2_2541_vehicles_cb_articulation;
 		additional_text: return string(STR_CFG_TRUCK_TRAILER);
 		random_trigger: mbactros2_2541_graphics_vehicles_random_freight_color;
@@ -903,7 +912,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_vehicles_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2_2541_container_cb_articulation, extra_callback_info1) {
-	1: return ID_4E_mbactros2_2541_container;
+	1: return ID_4E_mbactros2_2541_container_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -1034,7 +1043,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_container_with_trailer) {
         running_cost_base:RUNNING_COST_ROADVEH;
         sprite_id:SPRITE_ID_NEW_ROADVEH;
         cargo_capacity:12; // 8t + 16t in trailer
-		default_cargo_type:DEFAULT_CARGO_FIRST_REFITTABLE;
+		default_cargo_type:GOOD;
 		cost_factor:4;
 		refit_cost:0;
 		sound_effect:SOUND_DEPARTURE_OLD_RV_2;
@@ -1052,6 +1061,8 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_container_with_trailer) {
 	graphics {
 		default: mbactros2_2541_switch_graphics_container;
 		cargo_capacity: mbactros2_2541_cb_cargo_capacity;
+		// full capacity is 24t, but goods are 0.5t per item
+		purchase_cargo_capacity: return 24*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		articulated_part:mbactros2_2541_container_cb_articulation;
 		random_trigger: mbactros2_2541_graphics_container_random_freight_color;
@@ -1060,7 +1071,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_container_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2_2541_refrigerated_cb_articulation, extra_callback_info1) {
-	1: return ID_4E_mbactros2_2541_refrigerated;
+	1: return ID_4E_mbactros2_2541_refrigerated_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -1136,6 +1147,8 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_refrigerated_with_trailer) {
 	graphics {
 		default: mbactros2_2541_switch_graphics_refrigerated;
 		cargo_capacity: mbactros2_2541_cb_cargo_capacity;
+		// full capacity is 24t, but goods are 0.5t per item
+		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_CFG_TRUCK_TRAILER);
 		articulated_part:mbactros2_2541_refrigerated_cb_articulation;
 		purchase: mbactros2_2541_refrigerated_menu;
@@ -1143,7 +1156,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_refrigerated_with_trailer) {
 }
 
 switch(FEAT_ROADVEHS, SELF, mbactros2_2541_crane_cb_articulation, extra_callback_info1) {
-	1: return ID_4E_mbactros2_2541_open_crane;
+	1: return ID_4E_mbactros2_2541_open_crane_with_trailer;
 	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
 }
 
@@ -1174,7 +1187,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_open_crane) {
         running_cost_base:RUNNING_COST_ROADVEH;
         sprite_id:SPRITE_ID_NEW_ROADVEH;
         cargo_capacity:8;
-		default_cargo_type:GOOD;
+		default_cargo_type:STEL;
 		cost_factor:4;
 		refit_cost:0;
 		sound_effect:SOUND_DEPARTURE_OLD_RV_2;
@@ -1211,7 +1224,7 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_open_crane_with_trailer) {
         running_cost_base:RUNNING_COST_ROADVEH;
         sprite_id:SPRITE_ID_NEW_ROADVEH;
         cargo_capacity:12; // 8t + 16t in trailer
-		default_cargo_type:GOOD;
+		default_cargo_type:STEL;
 		cost_factor:4;
 		refit_cost:0;
 		sound_effect:SOUND_DEPARTURE_OLD_RV_2;
@@ -1231,6 +1244,8 @@ item(FEAT_ROADVEHS, ID_4E_mbactros2_2541_open_crane_with_trailer) {
 		default: mbactros2_2541_switch_graphics_crane;
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_TRAILER), string(STR_TRUCK_AUTOREFIT));
 		cargo_capacity: mbactros2_2541_cb_cargo_capacity;
+		// full capacity is 24t, but goods are 0.5t per item
+		purchase_cargo_capacity: return 12 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		articulated_part:mbactros2_2541_crane_cb_articulation;
 		purchase: mbactros2_2541_open_crane_menu;
 	}

--- a/src/truck/4F_mantga41660xxl.pnml
+++ b/src/truck/4F_mantga41660xxl.pnml
@@ -51,6 +51,11 @@ switch(FEAT_ROADVEHS, SELF,mantga41660xxl_cb_cargo_capacity,
 	return (80 * 16 * LOAD_TEMP(0)) / (cargo_unit_weight * 100);
 }
 
+switch(FEAT_ROADVEHS, SELF, mantga41660xxl_cb_articulation, extra_callback_info1) {
+	1: return ID_4F_mantga41660xxl;
+	return CB_RESULT_NO_MORE_ARTICULATED_PARTS;
+}
+
 item(FEAT_ROADVEHS, ID_4F_mantga41660xxl) {
 	property{
 		name: string(TRUCK_MAN_TGA_41660_XXL);
@@ -65,7 +70,7 @@ item(FEAT_ROADVEHS, ID_4F_mantga41660xxl) {
         running_cost_base:RUNNING_COST_ROADVEH;
         sprite_id:SPRITE_ID_NEW_ROADVEH;
         cargo_capacity:40;
-		default_cargo_type:DEFAULT_CARGO_FIRST_REFITTABLE;
+		default_cargo_type:GOOD;
 		cost_factor:4;
 		refit_cost:0;
 		sound_effect:SOUND_DEPARTURE_OLD_RV_2;
@@ -82,7 +87,9 @@ item(FEAT_ROADVEHS, ID_4F_mantga41660xxl) {
 	graphics {
 		default: mantga41660xxl_switch_graphics;
 		cargo_capacity: mantga41660xxl_cb_cargo_capacity;
-		purchase_cargo_capacity: return 40 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
+		// it should be 40t, but goods are 0.5t per item
+		purchase_cargo_capacity: return 80*2 * ((param_cargo_capacity == 0) ? 100 : param_cargo_capacity)/100; // doubled due to articulation
 		additional_text: return string(STR_PURCHASE_MENU2, string(STR_CFG_TRUCK_SEMITRAILER), string(STR_TRUCK_AUTOREFIT));
+		articulated_part:mantga41660xxl_cb_articulation;
 	}
 }


### PR DESCRIPTION
Articulated trucks showed a wrong capacity in the purchase menu due to different methods of calculating capacities.
MAN TGA XXL did not work at all due to missing articulation callback.